### PR TITLE
fix(proxy): include auth headers during SSR requests

### DIFF
--- a/src/runtime/server/api/proxy/storefront.ts
+++ b/src/runtime/server/api/proxy/storefront.ts
@@ -12,15 +12,18 @@ export default defineEventHandler(async (event) => {
 
     const body = await readValidatedBody(event, schema.parse)
 
-    const headers = getRequestHeaders(event) as Record<string, string>
+    const requestHeaders = getRequestHeaders(event) as Record<string, string>
 
     const { _shopify } = useRuntimeConfig()
 
-    const { apiUrl } = createStorefrontConfig(_shopify)
+    const { apiUrl, headers: storefrontHeaders } = createStorefrontConfig(_shopify)
 
     return await $fetch(apiUrl, {
         method: event.method,
-        headers,
+        headers: {
+            ...requestHeaders,
+            ...storefrontHeaders,
+        },
         body,
     })
 })


### PR DESCRIPTION
## Summary

Fixes #167

The proxy handler was ignoring the auth headers returned by `createStorefrontConfig`, causing `401 Unauthorized` errors during SSR.

## Problem

During **client-side** requests, the browser's SDK adds `X-Shopify-Storefront-Access-Token` to requests, which the proxy forwards via `getRequestHeaders(event)`. 

During **SSR**, the internal fetch to `/_proxy/storefront` has no auth headers because it's a server-to-server call within the same process.

## Solution

Merge the storefront auth headers (from config) with the incoming request headers:

```diff
- const { apiUrl } = createStorefrontConfig(_shopify)
+ const { apiUrl, headers: storefrontHeaders } = createStorefrontConfig(_shopify)

  return await $fetch(apiUrl, {
      method: event.method,
-     headers,
+     headers: {
+         ...requestHeaders,
+         ...storefrontHeaders,
+     },
      body,
  })
```

This ensures SSR requests are properly authenticated while still forwarding any other headers from the incoming request.

## Testing

Before this fix:
1. Configure `@nuxtjs/shopify` with Storefront API (default `proxy: true`)
2. Create a page using `useStorefrontData` to fetch products
3. Navigate to the page via client-side link → works ✅
4. Hard refresh the page (SSR) → 401 Unauthorized ❌

After this fix:
- Both client-side navigation and SSR work correctly ✅