### PR TITLE
fix(docs): correct product response shape in usage example

### DIFF
--- a/docs/content/1.getting-started/4.usage.md
+++ b/docs/content/1.getting-started/4.usage.md
@@ -59,7 +59,7 @@ Once configured, you can use the `useStorefront` and `useStorefrontData` composa
   <script setup lang="ts">
   const storefront = useStorefront()
 
-  const { data: product } = await storefront.request(`#graphql
+  const { data } = await storefront.request(`#graphql
     query GetProduct($handle: String!) {
       product(handle: $handle) {
         id
@@ -75,9 +75,9 @@ Once configured, you can use the `useStorefront` and `useStorefrontData` composa
   </script>
 
   <template>
-    <div v-if="product">
-        <h1>{{ product.product.title }}</h1>
-        <p>{{ product.product.description }}</p>
+    <div v-if="data">
+      <h1>{{ data.product.title }}</h1>
+      <p>{{ data.product.description }}</p>
     </div>
   </template>
   ```
@@ -88,7 +88,7 @@ Once configured, you can use the `useStorefront` and `useStorefrontData` composa
   <script setup lang="ts">
   const handle = 'high-top-sneakers'
 
-  const { data: product } = await useStorefrontData(`product-${handle}`, `#graphql
+  const { data } = await useStorefrontData(`product-${handle}`, `#graphql
     query GetProduct($handle: String!) {
       product(handle: $handle) {
         id
@@ -104,10 +104,10 @@ Once configured, you can use the `useStorefront` and `useStorefrontData` composa
   </script> 
 
   <template>
-    <div v-if="product">
-      <h1>{{ product.product.title }}</h1>
+    <div v-if="data">
+      <h1>{{ data.product.title }}</h1>
 
-      <p>{{ product.product.description }}</p>
+      <p>{{ data.product.description }}</p>
     </div>
   </template>
   ```


### PR DESCRIPTION
The usage example for `useStorefrontData` incorrectly referenced `product.title` and `product.description`, which do not exist at the top level of the returned data structure.

The GraphQL query returns an object shaped as:

{
  product: {
    id,
    title,
    description
  }
}

This commit updates the 4.usage.md example to properly reference `product.product.title` and `product.product.description`, ensuring the example matches the actual Storefront API response structure.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The usage example for useStorefrontData incorrectly referenced product.title and product.description, which do not exist on the top level of the returned data.

The GraphQL query returns:

{
  product: {
    id,
    title,
    description
  }
}


This PR updates the documentation to correctly reference product.product.title and product.product.description, ensuring the example matches the actual Storefront API response structure.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
