### PR TITLE
fix: correct installation command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Upcoming features and developments for the 1.0.0 release:
 Run the following command to install the module in your project:
 
 ```bash
-npx nuxt@latest module add nuxt-shopify
+npx nuxi@latest module add shopify
 ```
 
 <details>

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -25,15 +25,15 @@ You can start building without a store using [mock.shop](https://mock.shop) but 
     :::tabs-item{label="Guided"}
       :::code-group
         ```bash [npm]
-        npx nuxi@latest module add nuxt-shopify
+        npx nuxi@latest module add shopify
         ```
 
         ```bash [pnpm]
-        pnpx nuxi@latest module add nuxt-shopify
+        pnpx nuxi@latest module add shopify
         ```
 
         ```bash [bun]
-        bunx nuxi@latest module add nuxt-shopify
+        bunx nuxi@latest module add shopify
         ```
       :::
     :::


### PR DESCRIPTION
## Description

Fixes #186

The installation command in the documentation was showing the incorrect syntax:
- `npx nuxt@latest module add nuxt-shopify` (wrong)

This has been corrected to:
- `npx nuxi@latest module add shopify` (correct)

## Changes

- **README.md**: Fixed `npx nuxt@latest` to `npx nuxi@latest` and `nuxt-shopify` to `shopify`
- **docs/content/1.getting-started/2.installation.md**: Fixed module name from `nuxt-shopify` to `shopify` for all package managers (npm, pnpm, bun)